### PR TITLE
fix: change label orientation

### DIFF
--- a/src/modules/likertItem/LikertItem.tsx
+++ b/src/modules/likertItem/LikertItem.tsx
@@ -101,9 +101,8 @@ const LikertItem: FC<LikertItemProps> = ({
             typography: {
               sx: {
                 transformOrigin: 'top center',
-                transform: 'rotate(45deg) translate(0.5em, 0)',
-                writingMode: 'sideways-lr',
-                width: '100%',
+                transform: 'rotate(-45deg) translate(-0.5em, 0)',
+                writingMode: 'vertical-lr',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
               },


### PR DESCRIPTION
- the new style is supported by chrome (webkit)
- the labels may overflow on the left, where more space is usually available because of the buttons